### PR TITLE
Expose encryption functions

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,10 @@ pub enum SaltyError {
     #[fail(display = "No shared task found")]
     NoSharedTask,
 
+    /// Peer has not (yet) been determined.
+    #[fail(display = "Peer has not (yet) been determined")]
+    NoPeer,
+
     /// A problem occured related to a task.
     #[fail(display = "Task error: {}", _0)]
     Task(String),
@@ -64,6 +68,7 @@ impl From<SignalingError> for SaltyError {
             SignalingError::InvalidNonce(_) => SaltyError::Protocol(e.to_string()),
             SignalingError::InvalidStateTransition(_) => SaltyError::Crash(e.to_string()),
             SignalingError::NoSharedTask => SaltyError::NoSharedTask,
+            SignalingError::NoPeer => SaltyError::NoPeer,
             SignalingError::Protocol(msg) => SaltyError::Protocol(msg),
             SignalingError::SendError => SaltyError::Network(e.to_string()),
             SignalingError::TaskInitialization(_) => SaltyError::Task(e.to_string()),
@@ -133,6 +138,10 @@ pub(crate) enum SignalingError {
     /// No shared task was found during the handshake.
     #[fail(display = "No shared task found")]
     NoSharedTask,
+
+    /// Peer has not (yet) been determined.
+    #[fail(display = "Peer has not (yet) been determined")]
+    NoPeer,
 
     /// Task initialization failed.
     #[fail(display = "Task initialization failed: {}", _0)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,13 @@ impl SaltyClient {
         self.signaling.current_peer_sequence_numbers()
     }
 
+    /// Encrypt raw bytes using the session keys after the handshake has been finished.
+    pub fn encrypt_raw_with_session_keys(&self, data: &[u8], nonce: &[u8]) -> SaltyResult<Vec<u8>> {
+        let sodium_nonce = box_::Nonce::from_slice(nonce)
+            .ok_or(SaltyError::Crypto("Invalid nonce bytes".into()))?;
+        Ok(self.signaling.encrypt_raw_with_session_keys(data, &sodium_nonce)?)
+    }
+
     /// Decrypt raw bytes using the session keys after the handshake has been finished.
     pub fn decrypt_raw_with_session_keys(&self, data: &[u8], nonce: &[u8]) -> SaltyResult<Vec<u8>> {
         let sodium_nonce = box_::Nonce::from_slice(nonce)

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -17,6 +17,7 @@ use boxes::{ByteBox, OpenBox};
 use crypto::{KeyPair, AuthToken, PublicKey};
 use errors::{SignalingError, SignalingResult, SaltyError, ValidationError};
 use rmpv::{Value};
+use rust_sodium::crypto::box_;
 
 pub(crate) mod context;
 pub(crate) mod cookie;
@@ -796,6 +797,24 @@ pub(crate) trait Signaling {
         );
 
         Ok(HandleAction::Reply(bbox))
+    }
+
+    // Raw encryption / decryption
+
+    /// Decrypt raw bytes for the peer using the session keys.
+    ///
+    /// If this function is called before the peer has been established,
+    /// it will return a `SignalingError::NoPeer`.
+    fn decrypt_raw_with_session_keys(&self, data: &[u8], nonce: &box_::Nonce) -> SignalingResult<Vec<u8>> {
+        let peer = self.get_peer()
+            .ok_or_else(|| SignalingError::NoPeer)?;
+        let peer_session_public_key = peer.session_key()
+            .ok_or_else(|| SignalingError::Crash("Peer session public key not set".into()))?;
+        let our_session_private_key = peer.keypair()
+            .map(|keypair: &KeyPair| keypair.private_key())
+            .ok_or_else(|| SignalingError::Crash("Our session private key not set".into()))?;
+        box_::open(data, nonce, peer_session_public_key, our_session_private_key)
+            .map_err(|_| SignalingError::Crypto("Could not decrypt bytes".into()))
     }
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -801,6 +801,21 @@ pub(crate) trait Signaling {
 
     // Raw encryption / decryption
 
+    /// Encrypt raw bytes for the peer using the session keys.
+    ///
+    /// If this function is called before the peer has been established,
+    /// it will return a `SignalingError::NoPeer`.
+    fn encrypt_raw_with_session_keys(&self, data: &[u8], nonce: &box_::Nonce) -> SignalingResult<Vec<u8>> {
+        let peer = self.get_peer()
+            .ok_or_else(|| SignalingError::NoPeer)?;
+        let peer_session_public_key = peer.session_key()
+            .ok_or_else(|| SignalingError::Crash("Peer session public key not set".into()))?;
+        let our_session_private_key = peer.keypair()
+            .map(|keypair: &KeyPair| keypair.private_key())
+            .ok_or_else(|| SignalingError::Crash("Our session private key not set".into()))?;
+        Ok(box_::seal(data, nonce, peer_session_public_key, our_session_private_key))
+    }
+
     /// Decrypt raw bytes for the peer using the session keys.
     ///
     /// If this function is called before the peer has been established,

--- a/src/protocol/tests/mod.rs
+++ b/src/protocol/tests/mod.rs
@@ -156,9 +156,9 @@ fn test_peer_sequence_number_with_peer() {
     }));
 }
 
-/// If there's no peer, raw decrypting should fail.
+/// If there's no peer, raw encrypting and decrypting should fail.
 #[test]
-fn test_decrypt_raw_with_session_keys_no_peer() {
+fn test_encrypt_decrypt_raw_with_session_keys_no_peer() {
     let signaling = InitiatorSignaling::new(
         KeyPair::new(),
         Tasks::new(Box::new(DummyTask::new(42))),
@@ -168,8 +168,44 @@ fn test_decrypt_raw_with_session_keys_no_peer() {
     );
     let nonce = box_::gen_nonce();
     assert_eq!(
+        signaling.encrypt_raw_with_session_keys(&[1, 2, 3], &nonce),
+        Err(SignalingError::NoPeer)
+    );
+    assert_eq!(
         signaling.decrypt_raw_with_session_keys(&[1, 2, 3], &nonce),
         Err(SignalingError::NoPeer)
+    );
+}
+
+/// Test encrypting raw bytes.
+#[test]
+fn test_encrypt_raw_with_session_keys_with_peer() {
+    // Generate keypairs and nonce
+    let peer_kp = KeyPair::new();
+    let our_kp = KeyPair::new();
+    let our_private_key_clone = our_kp.private_key().clone();
+    let nonce = box_::gen_nonce();
+
+    // Create signaling instance
+    let mut signaling = MockSignaling::new(
+        Role::Responder,
+        ClientIdentity::Responder(3),
+        SignalingState::Task,
+    );
+    let mut initiator = InitiatorContext::new(PublicKey::random());
+    initiator.session_key = Some(peer_kp.public_key().clone());
+    initiator.keypair = our_kp;
+    signaling.set_peer(initiator);
+
+    // Encrypt data
+    let data = [2, 3, 4, 5];
+    let ciphertext = signaling.encrypt_raw_with_session_keys(&data, &nonce).unwrap();
+    assert_ne!(&data, ciphertext.as_slice());
+
+    // Verify
+    assert_eq!(
+        box_::open(&ciphertext, &nonce, peer_kp.public_key(), &our_private_key_clone),
+        Ok(vec![2, 3, 4, 5])
     );
 }
 

--- a/src/protocol/tests/mod.rs
+++ b/src/protocol/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Protocol tests.
+use rust_sodium::crypto::box_;
 
 use ::test_helpers::{DummyTask, TestRandom};
 use super::*;
@@ -153,4 +154,57 @@ fn test_peer_sequence_number_with_peer() {
         incoming: (3 << 32) | 1234,
         outgoing: our_csn,
     }));
+}
+
+/// If there's no peer, raw decrypting should fail.
+#[test]
+fn test_decrypt_raw_with_session_keys_no_peer() {
+    let signaling = InitiatorSignaling::new(
+        KeyPair::new(),
+        Tasks::new(Box::new(DummyTask::new(42))),
+        None,
+        None,
+        None,
+    );
+    let nonce = box_::gen_nonce();
+    assert_eq!(
+        signaling.decrypt_raw_with_session_keys(&[1, 2, 3], &nonce),
+        Err(SignalingError::NoPeer)
+    );
+}
+
+/// Test decrypting raw bytes.
+#[test]
+fn test_decrypt_raw_with_session_keys_with_peer() {
+    // Generate keypairs and nonce
+    let peer_kp = KeyPair::new();
+    let our_kp = KeyPair::new();
+    let nonce = box_::gen_nonce();
+
+    // Encrypt data
+    let data = [1, 2, 3, 4];
+    let ciphertext = box_::seal(&data, &nonce, peer_kp.public_key(), our_kp.private_key());
+
+    // Create signaling instance
+    let mut signaling = MockSignaling::new(
+        Role::Responder,
+        ClientIdentity::Responder(3),
+        SignalingState::Task,
+    );
+    let mut initiator = InitiatorContext::new(PublicKey::random());
+    initiator.session_key = Some(peer_kp.public_key().clone());
+    initiator.keypair = our_kp;
+    signaling.set_peer(initiator);
+
+    // Decrypt with wrong nonce
+    assert_eq!(
+        signaling.decrypt_raw_with_session_keys(&ciphertext, &box_::gen_nonce()),
+        Err(SignalingError::Crypto("Could not decrypt bytes".into()))
+    );
+
+    // Decrypt with correct nonce
+    assert_eq!(
+        signaling.decrypt_raw_with_session_keys(&ciphertext, &nonce),
+        Ok(vec![1, 2, 3, 4])
+    );
 }


### PR DESCRIPTION
Make it possible to encrypt and decrypt messages using the session keys (once established).

FFI integration will need to be done in the relayed data task.