### PR TITLE
Ignore an unknown responder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ pub enum Event {
     /// Server handshake is done.
     ///
     /// The boolean indicates whether a peer is already
-    /// connected + authenticated.
+    /// connected + authenticated towards the server.
     ServerHandshakeDone(bool),
 
     /// Peer handshake is done.


### PR DESCRIPTION
This prevents the connection being teared down by a protocol error in case a message from an *unknown* responder has been received. This can happen since a message from a responder towards an initiator may still be in flight after the initiator dropped the responder.