### PR TITLE
Handle new-initiator/new-responder correctly

### DIFF
--- a/examples/chat/main.rs
+++ b/examples/chat/main.rs
@@ -243,8 +243,8 @@ fn main() {
 
     // Connect to server
     let (connect_future, event_channel) = saltyrtc_client::connect(
-            "localhost",
-            8765,
+            "server.saltyrtc.org",
+            443,
             Some(tls_connector),
             &core.handle(),
             salty_arc.clone(),
@@ -537,7 +537,7 @@ fn setup_logging(role: Role, log_to_stdout: bool) -> Config {
         .unwrap();
 
     // Instantiate filters
-    let info_filter = ThresholdFilter::new(LevelFilter::Info);
+    let info_filter = ThresholdFilter::new(LevelFilter::Debug);
 
     // Config builder
     let builder = Config::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ pub enum Event {
     /// Server handshake is done.
     ///
     /// The boolean indicates whether a peer is already
-    /// connected + authenticated.
+    /// connected + authenticated towards the server.
     ServerHandshakeDone(bool),
 
     /// Peer handshake is done.

--- a/src/protocol/tests/signaling_messages.rs
+++ b/src/protocol/tests/signaling_messages.rs
@@ -531,6 +531,7 @@ mod client_auth {
             HandleAction::HandshakeError(_) => panic!("Unexpected HandshakeError"),
             HandleAction::TaskMessage(_) => panic!("Unexpected TaskMessage"),
             HandleAction::Event(_) => panic!("Unexpected Event"),
+            HandleAction::Close(_) => panic!("Unexpected Close"),
         };
 
         let decrypted = OpenBox::<Message>::decrypt(

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -5,7 +5,7 @@ use std::result::Result as StdResult;
 use serde::ser::{Serialize, Serializer};
 use serde::de::{Deserialize, Deserializer, Visitor, Error as SerdeError};
 
-use crate::Event;
+use crate::{Event, CloseCode};
 use crate::boxes::ByteBox;
 use crate::errors::SaltyError;
 use crate::tasks::TaskMessage;
@@ -237,6 +237,8 @@ pub(crate) enum HandleAction {
     Event(Event),
     /// A task message was received and decoded.
     TaskMessage(TaskMessage),
+    /// Close the websocket with a specific close code.
+    Close(CloseCode),
 }
 
 


### PR DESCRIPTION
Resolves #61
Merge after #59 #67 

To do (@dbrgn): We still need to figure out how to close the task loop after the WebSocket close message has been enqueued. The issue can be reproduced by...

1. Creating a chat responder.
2. Connecting the first initiator.
3. Connecting the second initiator. This drops the first initiator from the path.
4. The second initiator is being picked up by the responder. The responder should close now but doesn't.