### PR TITLE
Lock version of array-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ serde = { version = "1", features = ["derive"] }
 tokio-core = "0.1"
 tokio-timer = "0.1"
 websocket = "0.21"
+array-macro = "=1.0.3"  # See https://gitlab.com/KonradBorowski/array-macro/issues/2,
+                        # remove as soon as we require Rust 1.36+
 
 [dev-dependencies]
 clap = "2"


### PR DESCRIPTION
Our builds currently break due to https://gitlab.com/KonradBorowski/array-macro/issues/2.

Lock array-macro so that we and other users don't immediately have to upgrade to Rust 1.36 the day after it's been released.