### PR TITLE
Handle connection closing by server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,6 +458,7 @@ pub fn connect(
             }
         })
         .map(move |client| {
+            debug!("Connected to {}", ws_url);
             let role = salty
                 .read()
                 .map(|s| s.role().to_string())


### PR DESCRIPTION
If the server closes the connection, stop the event loop but don't return an error.